### PR TITLE
change wording from application to workload

### DIFF
--- a/data/home.yaml
+++ b/data/home.yaml
@@ -50,7 +50,7 @@ single_spec:
 how_score_works:
   title: How Score works
   steps:
-    - title: "Create a <code class='how-it-works-title-code'>score.yaml</code> file for the application"
+    - title: "Create a <code class='how-it-works-title-code'>score.yaml</code> file for your workload"
       code:
         type: single
         content: |


### PR DESCRIPTION
We're not consistent. There should be a score file per workload not per application.