### PR TITLE
fix: fix css for small columns

### DIFF
--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
   <div class="flex flex-col items-center">
     {{ partial "blog/header" . }}
-    <div id="blog-post-content" class="max-w-3xl text-lg px-5 lg:px-0 my-16">
+    <div id="blog-post-content" class="max-w-4xl w-full text-lg px-5 my-16">
       {{ .Content | markdownify }}
       <a class="flex group items-center gap-x-2 mt-8" href="{{ site.BaseURL }}blog">
         <img 


### PR DESCRIPTION
We had a bug where the width of the article was extending beyond the page width on small < 48rem screen sizes. To fix this I've adjusted the blog post content classes:

1. Expand max width size from 48 to 56rem for readability
2. Add `w-full` to anchor article width to page width. This allows (1) to actually wrap smaller when the page is smaller than 56rem.
3. Removed lg:px-0 toggle since we don't need the width adjustment to toggle and can keep the 5rem margin at all times.

**Before**

![image](https://github.com/user-attachments/assets/e5d86609-95ab-414f-8f5d-06e99910ecf8)

**After**

![image](https://github.com/user-attachments/assets/53e8fdd2-7b2d-48f8-8dac-2f974283f96d)
